### PR TITLE
Publish thin CLI wrapper for stream publishing

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 /.idea/
 /cover.out
+/stream-publish

--- a/Makefile
+++ b/Makefile
@@ -1,13 +1,27 @@
+ifeq ($(OS),Windows_NT)
+PUBLISHER_BIN_PATH=./stream-publish.exe
+else
+PUBLISHER_BIN_PATH=./stream-publish
+endif
+
 # Get the currently used golang install path (in GOPATH/bin, unless GOBIN is set)
 ifeq (,$(shell go env GOBIN))
 GOBIN=$(shell go env GOPATH)/bin
 else
 GOBIN=$(shell go env GOBIN)
 endif
+GO_SOURCES = $(shell find . -type f -name '*.go')
 
 .PHONY: compile
 compile: fmt vet pkg/liiklus/LiiklusService.pb.go ## Compile target binaries
 	go build .
+
+$(PUBLISHER_BIN_PATH): $(GO_SOURCES) ## Compile stream-publish binary
+	go build  -o $(PUBLISHER_BIN_PATH) ./cmd/stream-publish/main.go
+
+.PHONY: clean
+clean:
+	rm -f $(PUBLISHER_BIN_PATH)
 
 pkg/liiklus/LiiklusService.pb.go: LiiklusService.proto
 	protoc -I . LiiklusService.proto --go_out=plugins=grpc:pkg/liiklus

--- a/cmd/stream-publish/main.go
+++ b/cmd/stream-publish/main.go
@@ -1,0 +1,44 @@
+package main
+
+import (
+	"bufio"
+	"context"
+	"flag"
+	"fmt"
+	"io"
+	"os"
+	"strings"
+
+	client "github.com/projectriff/stream-client-go"
+)
+
+func main() {
+	gateway := flag.String("gateway", "", "resolvable name of the streaming gateway")
+	topic := flag.String("topic", "", "logical topic name")
+	acceptableContentType := flag.String("accept", "*/*", "topic acceptable content type")
+	contentType := flag.String("content-type", "", "payload content type")
+	flag.Parse()
+
+	streamClient, err := client.NewStreamClient(*gateway, *topic, *acceptableContentType)
+	if err != nil {
+		panic(err)
+	}
+
+	fmt.Println("Write payload and <ENTER>, <CTRL-C> to stop")
+	reader := bufio.NewReader(os.Stdin)
+	for {
+		payload, err := reader.ReadString('\n')
+		if err == io.EOF {
+			break
+		}
+		if err != nil {
+			panic(err)
+		}
+		publishResult, err := streamClient.Publish(context.TODO(), strings.NewReader(payload), nil, *contentType, map[string]string{})
+		if err != nil {
+			panic(err)
+		}
+
+		fmt.Printf("Result published at offset: %d, partition: %d\n", publishResult.Offset, publishResult.Partition)
+	}
+}


### PR DESCRIPTION
Example local usage:
```
 $(terminal 1)> sudo kubefwd svc franz-gateway-4v8fj
 $(terminal 2)> ./stream-publish -gateway franz-gateway-4v8fj:6565 -topic ins -accept application/json -content-type application/json
Write payload and <ENTER>, <CTRL-C> to stop
2
Result published at offset: 56, partition: 0
3
Result published at offset: 57, partition: 0
2
Result published at offset: 58, partition: 0
```